### PR TITLE
fix(tabs-container): fix typo in html attribute `placeholder`

### DIFF
--- a/src/desktop/containers/tabs-container/tabs-container.component.html
+++ b/src/desktop/containers/tabs-container/tabs-container.component.html
@@ -1,4 +1,4 @@
-tabs<div layout-fill layout="row">
+<div layout-fill layout="row">
   <md-sidenav md-component-id="filters" class="md-sidenav-left">
     <div layout="column" flex>
       <md-input-container>


### PR DESCRIPTION
resolves #11 
