### PR TITLE
fix(transactions-container): change selectedItem to selectedOption

### DIFF
--- a/src/desktop/routes/transactions/containers/transactions-container/transactions-container.component.js
+++ b/src/desktop/routes/transactions/containers/transactions-container/transactions-container.component.js
@@ -50,11 +50,11 @@ module.exports = ngModule => {
 
     function _refreshData() {
       ctrl.loading = true;
-      const dateRangeFilter = (typeof ctrl.dateRangeDropdownSelectedItem !== 'undefined' ?
-          ctrl.dateRangeDropdownSelectedItem.value : undefined);
+      const dateRangeFilter = (typeof ctrl.dateRangeDropdownSelectedOption !== 'undefined' ?
+          ctrl.dateRangeDropdownSelectedOption.value : undefined);
       const totalsPromise = transactionsAnalyticsFactory.getTotals(_categoryFilter, dateRangeFilter);
       const chartDataPromise = transactionsAnalyticsFactory
-        .getTransactionsPerX(_categoryFilter, ctrl.granularityDropdownSelectedItem, dateRangeFilter);
+        .getTransactionsPerX(_categoryFilter, ctrl.granularityDropdownSelectedOption, dateRangeFilter);
       return $q.all([totalsPromise, chartDataPromise]).then(data => {
         ctrl.pillData[0].chart = _formatDataForLineChart('Income', data[1], 'total');
         ctrl.pillData[1].chart = _formatDataForLineChart('Products Sold', data[1], 'quantity');


### PR DESCRIPTION
A merge conflict or automatic merge erroneously changed variable names to be suffixed with "Item"
instead of "Option", making the date range and date grain selectors silently fail. This commit fixes
that change.

@bmbarker90 
