### PR TITLE
Copy contents of domo/ (not dir) into dist/

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "tdd": "NODE_ENV=test karma start ./karma.conf.js --browsers Chrome",
     "lint": "eslint src/**",
     "coveralls": "npm run test-ci && node node_modules/lcov-filter/index.js ./coverage/phantomjs/lcov.info spec | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
-    "build": "rm -rf ./dist && NODE_ENV=production ./node_modules/.bin/webpack && cp -r domo/ dist/",
+    "build": "rm -rf ./dist && NODE_ENV=production ./node_modules/.bin/webpack && cp -r domo/* dist/",
     "preversion": "npm run test-ci",
     "version": "npm run build && npm run changelog && git add -A CHANGELOG.md",
     "postversion": "git push && git push --tags",


### PR DESCRIPTION
Do not affect OSX, where this worked previously. Fixes build on Linux.
Port of https://github.com/DomoApps/starter-kit/pull/62

Resolves #23